### PR TITLE
Add macro support, implement disambiguation, and multi-file support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "auto-import"
 description = "Please do not use this."
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "BSD-2-Clause"
 repository = "https://github.com/m-ou-se/auto-import"
@@ -11,3 +11,5 @@ proc_macro = true
 
 [dependencies]
 json = "0.12.4"
+rand = "0.8.5"
+lazy_static = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,12 @@
-use proc_macro::TokenStream;
-use std::collections::BTreeSet;
-use std::io::{stderr, stdout, Write};
-use std::process::{exit, Command};
+#![feature(proc_macro_span)]
+
+use json::JsonValue;
+use lazy_static::lazy_static;
+use proc_macro::{Span, TokenStream};
+use std::collections::{HashMap, HashSet};
+use std::process;
 use std::str::FromStr;
-use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use std::sync::Mutex;
 
 #[proc_macro]
 pub fn magic(input: TokenStream) -> TokenStream {
@@ -12,62 +15,244 @@ pub fn magic(input: TokenStream) -> TokenStream {
         "auto_import::magic!() takes no arguments!"
     );
 
-    static ONCE: AtomicBool = AtomicBool::new(false);
-
-    if ONCE.swap(true, Relaxed) {
-        panic!("don't call auto_import::magic!() more than once per crate!");
+    let file = Span::call_site().source_file();
+    if !file.is_real() {
+        // I don't know why this would ever be false or what a fake file even means, so don't handle it
+        return input;
     }
 
-    if let Ok(x) = std::env::var("autoimport") {
+    // JSON output contains paths which ig is UTF-8 too. not quite sure what that's about.
+    // i think this'll panic with non-UTF8 stuff because of that, so therefore i assume valid UTF-8
+    let file = file.path();
+    let file = file.to_str().expect("valid UTF-8");
+
+    // uhh idk what's valid in env vars, from a quick google search it seems just alphanumeric and _ so better safe than sorry
+    let custom_key: String = "autoimport_"
+        .chars()
+        .chain(file.chars().filter(char::is_ascii_alphanumeric))
+        .collect();
+    let custom_key = custom_key.as_str();
+
+    if let Ok(x) = std::env::var(custom_key) {
         return TokenStream::from_str(&x).unwrap();
     }
 
-    let mut imports = BTreeSet::new();
+    // autoimport launched this process to check for errors, but this is NOT the correct invocation of the macro
+    if let Ok(_) = std::env::var("autoimport") {
+        return input;
+    }
+
+    lazy_static! {
+        static ref ONCE: Mutex<HashSet<String>> = Mutex::new(HashSet::new());
+    }
+
+    {
+        let mut files = ONCE.lock().unwrap();
+        if files.contains(custom_key) {
+            // this poisons future invocations but uh, i guess that just prevents extra resources from being used for invalid invocations
+            panic!("don't call auto_import::magic!() more than once per file!");
+        }
+        files.insert(custom_key.to_string());
+    }
+
+    let mut imports = HashSet::<String>::new();
+    let mut more_imports = HashSet::<String>::new();
+    let mut excluded = HashSet::<String>::new();
 
     let mut attempts = 0;
     loop {
         attempts += 1;
         let mut change = false;
         let mut args = std::env::args_os();
-        let out = Command::new(args.next().unwrap())
+        let out = process::Command::new(args.next().unwrap())
             .args(args.filter(|arg| {
                 arg.to_str()
                     .map_or(true, |s| !s.starts_with("--error-format="))
             }))
             .arg("--error-format=json")
+            .env("autoimport", "YES_SO_DONT_EVEN_TRY_ANYTHING")
             .env(
-                "autoimport",
-                imports.iter().map(String::as_str).collect::<String>(),
+                custom_key,
+                imports
+                    .iter()
+                    .flat_map(|s| ["use ", s, ";"])
+                    .collect::<String>(),
             )
             .output()
             .unwrap();
         if out.status.success() {
-            exit(0);
+            process::exit(0);
         }
         for line in std::str::from_utf8(&out.stderr)
             .unwrap()
             .lines()
             .filter(|l| l.starts_with('{'))
         {
-            if let Ok(d) = json::parse(line) {
-                for c in d["children"].members() {
-                    let suggestion = c["spans"][0]["suggested_replacement"]
-                        .as_str()
-                        .unwrap_or_default();
-                    if c["spans"][0]["text"].is_empty()
-                        && suggestion.starts_with("use ")
-                        && imports.insert(suggestion.to_string())
-                    {
-                        println!("\x1b[1;32m   Injecting\x1b[m {}", suggestion.trim());
-                        change = true;
-                    }
+            if let Ok(json) = json::parse(line) {
+                // Ensure the file name matches.
+                if json["spans"].members().any(|span| {
+                    // assert_eq will contain "similarly named macro `assert` defined here"
+                    // with "is_primary": false, so therefore only check path for the
+                    span["is_primary"].as_bool().unwrap_or(false)
+                        && span["file_name"]
+                            .as_str()
+                            .map_or(false, |error_file| error_file != file)
+                }) {
+                    continue;
+                }
+                if json["children"].members().any(|c| {
+                    c["spans"].members().any(|span| {
+                        span["file_name"]
+                            .as_str()
+                            .map_or(false, |error_file| error_file != file)
+                    })
+                }) {
+                    continue;
+                }
+                let suggestions: Vec<&str> = error(&json)
+                    .into_iter()
+                    .filter(|&s| !imports.contains(s))
+                    .collect();
+                if !suggestions.is_empty() {
+                    more_imports.extend(
+                        suggestions
+                            .into_iter()
+                            .filter(|&s| !excluded.contains(s))
+                            .map(Into::into),
+                    );
+                    change = true;
                 }
             }
         }
+
+        for import in &imports {
+            more_imports.remove(import);
+        }
+
+        if more_imports.len() > 1 {
+            let mut idents: HashMap<String, Vec<String>> = HashMap::new();
+            for suggestion in more_imports.drain() {
+                let ident = suggestion.split("::").last().unwrap();
+                let suggestions_for_ident = idents.entry(ident.to_string()).or_default();
+                suggestions_for_ident.push(suggestion);
+            }
+            for (ident, suggestions) in idents {
+                let (best, exclude) = disambiguate(ident, suggestions);
+                println!("\x1b[1;32m   Injecting\x1b[m for {best}");
+                imports.insert(best);
+                for bad in exclude {
+                    excluded.insert(bad);
+                }
+            }
+        }
+
         if !change || attempts == 10 {
-            stderr().write_all(&out.stderr).unwrap();
-            stdout().write_all(&out.stdout).unwrap();
-            exit(out.status.code().unwrap_or(1));
+            return TokenStream::from_str(
+                &imports
+                    .iter()
+                    .flat_map(|s| ["use ", s, ";"])
+                    .collect::<String>(),
+            )
+            .unwrap();
         }
     }
+}
+
+fn error<'a>(json: &'a JsonValue) -> Vec<&'a str> {
+    if json["code"].is_null() {
+        let message = json["message"].as_str().unwrap_or_default();
+        if extract("cannot find macro `", message, "` in this scope").is_some() {
+            let message = json["children"][0]["message"].as_str().unwrap_or_default();
+            if let Some(suggestions) =
+                extract("consider importing one of these items:", message, "")
+            {
+                return suggestions
+                    .split_terminator("\n")
+                    .filter(|s| !s.is_empty())
+                    .collect();
+            } else if let Some(suggestion) =
+                extract("consider importing this macro:\n", message, "")
+            {
+                return vec![suggestion];
+            }
+        }
+    }
+    json["children"]
+        .members()
+        .flat_map(|c| {
+            c["spans"]
+                .members()
+                .map(|s| s["suggested_replacement"].as_str().unwrap_or_default())
+                .filter(|s| !s.is_empty())
+                .filter_map(|s| extract("use ", s.trim(), ";"))
+        })
+        .collect()
+}
+
+fn extract<'a>(start: &'static str, message: &'a str, end: &'static str) -> Option<&'a str> {
+    if message.starts_with(start) && message.ends_with(end) {
+        Some(&message[start.len()..(message.len() - end.len())])
+    } else {
+        None
+    }
+}
+
+fn disambiguate(ident: String, mut suggestions: Vec<String>) -> (String, Vec<String>) {
+    assert!(!suggestions.is_empty());
+    if suggestions.len() == 1 {
+        return (suggestions.remove(0), Vec::new());
+    }
+    for i in 0..(suggestions.len() - 1) {
+        for j in (i + 1)..suggestions.len() {
+            if std_and_core(&ident, &suggestions[i], &suggestions[j]) {
+                suggestions.swap_remove(j);
+                return disambiguate(ident, suggestions);
+            } else if std_and_core(&ident, &suggestions[j], &suggestions[i]) {
+                suggestions.swap_remove(i);
+                return disambiguate(ident, suggestions);
+            }
+        }
+    }
+
+    println!("\x1b[1;32m   Ambiguity\x1b[m for {ident}");
+    println!("\x1b[1;32m     Between\x1b[m {} items", suggestions.len());
+    for import in &suggestions {
+        println!("\x1b[1;32m            \x1b[m {import}");
+    }
+    const DEFAULTS: &[&str] = &[
+        "std::ops::Range", // also includes BTreeMap/BTreeSet ranges
+    ];
+
+    if let Some(index) = suggestions
+        .iter()
+        .position(|s| DEFAULTS.contains(&s.as_str()))
+    {
+        let result = suggestions.swap_remove(index);
+        println!("\x1b[1;32m     Picking\x1b[m {result}");
+        return (result, suggestions);
+    }
+
+    use rand::prelude::*;
+
+    println!("\x1b[1;32m  Don't know\x1b[m which is best");
+    println!("\x1b[1;32m     Picking\x1b[m at random");
+    let index = (0..suggestions.len()).choose(&mut thread_rng()).unwrap();
+    let result = suggestions.swap_remove(index);
+    println!("\x1b[1;32mEnded up with\x1b[m {result}");
+    return (result, suggestions);
+}
+
+#[allow(non_upper_case_globals)]
+fn std_and_core(ident: &str, a: &str, b: &str) -> bool {
+    const std: &str = "std::";
+    const core: &str = "core::";
+    let r = a.starts_with(std) && b.starts_with(core) && a[std.len()..] == b[core.len()..];
+    if r {
+        println!("\x1b[1;32m   Ambiguity\x1b[m for {ident}");
+        println!("\x1b[1;32m     Between\x1b[m 2 items");
+        println!("\x1b[1;32m            \x1b[m {a}");
+        println!("\x1b[1;32m            \x1b[m {b}");
+        println!("\x1b[1;32m     Picking\x1b[m {a}");
+    }
+    r
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,7 @@ pub fn magic(input: TokenStream) -> TokenStream {
     let mut more_imports = HashSet::<String>::new();
     let mut excluded = HashSet::<String>::new();
 
-    let mut attempts = 0;
-    loop {
-        attempts += 1;
-        let mut change = false;
+    for _ in 0..10 {
         let mut args = std::env::args_os();
         let out = process::Command::new(args.next().unwrap())
             .args(args.filter(|arg| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,6 @@ pub fn magic(input: TokenStream) -> TokenStream {
                             .filter(|&s| !excluded.contains(s))
                             .map(Into::into),
                     );
-                    change = true;
                 }
             }
         }
@@ -144,6 +143,10 @@ pub fn magic(input: TokenStream) -> TokenStream {
                     excluded.insert(bad);
                 }
             }
+            change = true;
+        } else if more_imports.len() == 1 {
+            imports.extend(more_imports.drain());
+            change = true;
         }
 
         if !change || attempts == 10 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,17 +218,27 @@ fn disambiguate(ident: String, mut suggestions: Vec<String>) -> (String, Vec<Str
     }
 
     println!("\x1b[1;33m   Ambiguity\x1b[m for {ident}");
+    // 1. prelude first
+    // 2. stable over unstable
+    // 3. more common (such as std::ops) over uncommon (like collection-specific things)
+    // list the excluded things as well
     const DEFAULTS: &[&str] = &[
-        // instead of:
-        // std::collections::btree_map::Range
-        // std::collections::btree_set::Range
+        // (more common)
+        // - std::collections::btree_map::Range
+        // - std::collections::btree_set::Range
         "std::ops::Range",
-        // instead of:
-        // std::fmt::Result
-        // std::io::Result
-        // std::thread::Result
-        // (with no_implicit_prelude)
+        // (prelude)
+        // - std::fmt::Result
+        // - std::io::Result
+        // - std::thread::Result
         "std::result::Result",
+        // (prelude)
+        // - std::fmt::Error
+        // - std::io::Error
+        "std::error::Error",
+        // (unstable)
+        // - std::io::read_to_string
+        "std::fs::read_to_string",
     ];
 
     if let Some(index) = suggestions
@@ -241,7 +251,11 @@ fn disambiguate(ident: String, mut suggestions: Vec<String>) -> (String, Vec<Str
 
     use rand::prelude::*;
 
-    println!("\x1b[1;33m  Don't know\x1b[m which is best");
+    for suggestion in &suggestions {
+        println!("\x1b[1;31m            \x1b[m {suggestion}");
+    }
+
+    println!("\x1b[1;31m  Don't know\x1b[m which is best");
     println!("\x1b[1;32m     Picking\x1b[m at random");
     let index = (0..suggestions.len()).choose(&mut thread_rng()).unwrap();
     let result = suggestions.swap_remove(index);


### PR DESCRIPTION
"once per crate" has been extended to "once per file"
- To implement this, each file has its own environment variable for the uses, and the "autoimport" variable signals to other invocations that it is not their turn to look for shit right now. The static global is still thread-safe

Macros are now supported
- They are parsed very differently because for some reason they are not assigned an E#### compiler error code, and are just inline into a single string??

It also disambiguates some things:
- If there are ``std::`` and ``core::`` suggestions, it will pick the ``std::`` version
- If there are multiple, unrelated suggestions for the same identifier, with a most common option, it will pick the most common option (only std::ops::Range for now, which is more common that btree ranges i assume, but it is just a constant list that one can easily extend)
- Otherwise, it picks one at random, such that you can continue using ``auto_import``, but it may take multiple runs of the compiler to actually compiler successfully. If you ever support a "whichever_compiles" mode, that's the part you'd wanna change

I've pretty much rewritten most of this crate, so i also bumped it up a minor version to ``0.2.0``

Also, now, when it runs out of "attempts":

- it will return the built up imports, instead of erroring out directly. Because that way, it does as much as it can, and maybe compiles? instead of force exiting